### PR TITLE
Correct issuse with dependency specification

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -11,15 +11,16 @@ plugins {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
+    implementation(kotlin("stdlib"))
     implementation(Deps.Ktor.server)
-    implementation(Deps.Moshi.reflection)
+    implementation(Deps.Moshi.moshi)
     implementation(Deps.okio)
 
     testImplementation(Deps.Junit.api)
     testRuntimeOnly(Deps.Junit.engine)
     testImplementation(Deps.hamkrest)
     testImplementation(Deps.Ktor.testHost)
+    testImplementation(Deps.Moshi.reflection)
     testImplementation(kotlin("reflect"))
     "kaptTest"(Deps.Moshi.codeGen)
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -16,15 +16,10 @@ tasks.withType<KotlinCompile> {
 
 dependencies {
     implementation(project(":library"))
-    implementation(kotlin("stdlib-jdk8"))
+    implementation(kotlin("stdlib"))
     implementation(Deps.Ktor.netty)
     implementation(Deps.logback)
     implementation(Deps.Moshi.adapters)
     implementation(Deps.Moshi.moshi)
-    implementation(Deps.Moshi.reflection)
     "kapt"(Deps.Moshi.codeGen)
-
-    testImplementation(Deps.Junit.api)
-    testRuntimeOnly(Deps.Junit.engine)
-    testImplementation(Deps.hamkrest)
 }


### PR DESCRIPTION
library:
* stdlib is sufficient instead of requiring stdlib-jdk8
* moshi is sufficient instead of requiring moshi-kotlin
* tests require moshi-kotlin for reflection
sample:
* stdlib is sufficient instead of requiring stdlib-jdk8
* moshi-kotlin is not required because reflection is not used
* no tests, so no test dependencies