### PR TITLE
Publish coverage data from CI first

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,6 +27,15 @@ jobs:
       - name: Check
         run: "gradle core:check"
 
+      - name: Publish coverage results to Codecov
+        uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2 # v3.1.3
+        with:
+          file: core/build/reports/jacoco/test/jacocoTestReport.xml
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+        # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}
+
       - name: Upload test results artifact
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
@@ -40,15 +49,6 @@ jobs:
         with:
           name: test-coverage
           path: core/build/reports/jacoco/test/jacocoTestReport.xml
-        # Use always() to always run this step to publish test results when there are test failures
-        if: ${{ always() }}
-
-      - name: Publish coverage results to Codecov
-        uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2 # v3.1.3
-        with:
-          file: core/build/reports/jacoco/test/jacocoTestReport.xml
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}
 


### PR DESCRIPTION
Pull requests depend on CodeCov responding back with the coverage checks. Publishing this information before uploading other artifacts will give CodeCov more time to process the information.