### PR TITLE
Bump version: 2.1.0 → 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,3 +61,4 @@ artifact and package import names.
 ## [1.0.0] - 2018-09-12
 
 * Initial Release
+


### PR DESCRIPTION
Fake bump to retry automated release

Actual version bump in #66 