### PR TITLE
Update Kotlin to latest 1.9 & Moshi to latest 1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Update project dependencies:
     * JDK to `17`
+    * Kotlin to `1.9.25`
+    * moshi to `1.15.2`
 
 ### Internal
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-kotlin = "1.7.22"
+kotlin = "1.9.25"
 ktor = "2.2.4"
-moshi = "1.14.0"
+moshi = "1.15.2"
 hamkrest = "1.8.0.1"
 junit = "5.9.2"
 logback = "1.3.5"


### PR DESCRIPTION
Ideally, Moshi would be updated independently. But it was necessary to work with updated KAPT version.