### PR TITLE
Explicit platform laucher instead of implicit engine usage

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -19,8 +19,8 @@ dependencies {
     api(libs.ktor.serialization)
     api(libs.moshi)
 
-    testImplementation(libs.junit.api)
-    testRuntimeOnly(libs.junit.engine)
+    testImplementation(platform(libs.junit.bom))
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation(libs.hamkrest)
     testImplementation(libs.ktor.server.testHost)
     testImplementation(libs.moshi.reflection)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
 
     testImplementation(platform(libs.junit.bom))
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     testImplementation(libs.hamkrest)
     testImplementation(libs.ktor.server.testHost)
     testImplementation(libs.moshi.reflection)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,8 +34,7 @@ ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref =
 
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin"}
 
-junit-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit" }
-junit-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit" }
+junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit" }
 
 hamkrest = { group = "com.natpryce", name = "hamkrest", version.ref = "hamkrest" }
 logback = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback"}


### PR DESCRIPTION
Switch to using the BOM because the platform libraries don't have the same version number as the API.